### PR TITLE
fix: brew tap knative/client fails

### DIFF
--- a/kn@0.14.rb
+++ b/kn@0.14.rb
@@ -1,6 +1,6 @@
 require "FileUtils"
 
-class Kn < Formula
+class KnAT014 < Formula
   homepage "https://github.com/knative/client"
 
   v = "v0.14.0"


### PR DESCRIPTION
When tapping knative/client homebrew expects the tagged Formula to be named differend and currently fails even though we try to install the current `0.15` version which is declared in `kn.rb`

Logs:
```
==> Tapping knative/client
Cloning into '/usr/local/Homebrew/Library/Taps/knative/homebrew-client'...
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/knative/homebrew-client/kn@0.14.rb
Error: Cannot tap knative/client: invalid syntax in tap!
No available formula with the name "kn@0.14"
In formula file: /usr/local/Homebrew/Library/Taps/knative/homebrew-client/kn@0.14.rb
Expected to find class KnAT014, but only found: Kn.
Tapping knative/client has failed!
Warning: 'knative/client/kn' formula is unreadable: No available formula with the name "knative/client/kn"
Please tap it and then try again: brew tap knative/client
```