### PR TITLE
Require "fileutils" on macOS #20

### DIFF
--- a/kn.rb
+++ b/kn.rb
@@ -1,8 +1,4 @@
-if OS.mac?
-  require "FileUtils"
-else
-  require "fileutils"
-end
+require "fileutils"
 
 class Kn < Formula
   homepage "https://github.com/knative/client"


### PR DESCRIPTION
# Changes

- :bug: Prevent duplicate require and spam of warnings on macOS post install


/kind bug

Fixes #20 


**Release Note**

```release-note
No more fileutils warnings generated after `brew tap knative/client` on macOS
```

**Docs**

```docs
- [knative/docs]: #20
```
