### PR TITLE
Add note to fix upgrade with main default branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ Alternatively you can also install the clients directly (without adding a tap gl
 ```
 brew install knative/client/kn
 ```
+
+This repo is now using `main` as default branch. If you had tapped `knative/client` earlier,
+and now unable to upgrade `kn`, it's because brew could not locate the respective refs in this
+repo. To fix it, you'd need to tap the repo afresh (with `main` default branch)
+
+```
+brew uninstall kn
+brew untap knative/client --force
+brew tap knative/client
+brew install kn
+```


### PR DESCRIPTION
brew clones the formulas in your machine and `brew upgrade` will pull latest formulas. Users having
tapped the `knative/homebrew-client` repo locally, `brew` could not locate the `master` branch
and ended up kn@0.19 as the latest version. Added a note in readme to tap afresh to get latest kn version.