### PR TITLE
Update client to v1.1.0

### DIFF
--- a/kn@1.0.rb
+++ b/kn@1.0.rb
@@ -1,17 +1,17 @@
 require "fileutils"
 
-class Kn < Formula
+class KnAT10 < Formula
   homepage "https://github.com/knative/client"
 
-  v = "knative-v1.1.0"
+  v = "knative-v1.0.0"
   version v
 
   if OS.mac?
     url "https://github.com/knative/client/releases/download/#{v}/kn-darwin-amd64"
-    sha256 "580005a67fda65170c60e85236fccbc6467176e694be0944f65a5ff42f216d47"
+    sha256 "7ca666b399b481fb6dd003535feeb8c9d3cf969ad50d481e9159b5770fba7844"
   else
     url "https://github.com/knative/client/releases/download/#{v}/kn-linux-amd64"
-    sha256 "13099d3c62615823a2414b2fd0be4b3b56f3ee1a12f221b0719054ef7dd4ef02"
+    sha256 "47fe4465e4d802a7d03ab01fe367af2ddda23b5eb4d87b575d83a9f32ba83a34"
   end
 
   def install


### PR DESCRIPTION
As per title, this patch bumps client to v1.1.0 like https://github.com/knative/homebrew-client/pull/36

/cc @rhuss @maximilien @dsimansk 