### PR TITLE
Update class name in kn@1.6.rb to KnAT16

### DIFF
--- a/kn@1.6.rb
+++ b/kn@1.6.rb
@@ -1,6 +1,6 @@
 require "fileutils"
 
-class Kn < Formula
+class KnAT16 < Formula
   homepage "https://github.com/knative/client"
 
   v = "knative-v1.6.0"


### PR DESCRIPTION
If you update to a new version you apparently need to update the class name. See kb@1.5.rb

<!-- Thanks for sending a pull request! -->

# Changes

When trying to install kn I get the following error:

==> Tapping knative/client
Cloning into '/usr/local/Homebrew/Library/Taps/knative/homebrew-client'...
remote: Enumerating objects: 237, done.
remote: Counting objects: 100% (148/148), done.
remote: Compressing objects: 100% (59/59), done.
remote: Total 237 (delta 119), reused 104 (delta 88), pack-reused 89
Receiving objects: 100% (237/237), 65.86 KiB | 2.27 MiB/s, done.
Resolving deltas: 100% (144/144), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/knative/homebrew-client/kn@1.6.rb
No available formula with the name "kn@1.6". Did you mean kn@1.6, kn@1.0, kn@1.2, kn@1.5, kn@1.4, kn@1.3, kn@1.1 or kn@0.26?
In formula file: /usr/local/Homebrew/Library/Taps/knative/homebrew-client/kn@1.6.rb
Expected to find class KnAT16, but only found: Kn.
Error: Cannot tap knative/client: invalid syntax in tap!

Looking at the error and formula's for previous versions I deduced that the class name should be changed to the one suggested bij brew install

- :bug: Fix bug